### PR TITLE
Vec.Anglemod

### DIFF
--- a/Client/Source/WebQuake/Vec.js
+++ b/Client/Source/WebQuake/Vec.js
@@ -66,9 +66,7 @@ Vec.RotatePointAroundVector = function(dir, point, degrees)
 
 Vec.Anglemod = function(a)
 {
-	if (a >= 0.0)
-		return a - 360.0 * Math.floor(a / 360.0);
-	return a + 360.0 * (1 - Math.floor(-a / 360.0));
+	return (a % 360.0 + 360.0) % 360.0;
 };
 
 Vec.BoxOnPlaneSide = function(emins, emaxs, p)


### PR DESCRIPTION
As far as I understand, this method should return value in range [0, 360). However, `Vec.Anglemod(-360.0)` returns `-360`. Moreover, `Vec.Anglemod(-720.0)` yields `-1080`!

This straightforward implementation contains fix of this issue _(if it is an issue of course)_ and approx. 30% speedup.
