### PR TITLE
Frame init fix

### DIFF
--- a/Client/WebQuake/Mod.js
+++ b/Client/WebQuake/Mod.js
@@ -1133,6 +1133,11 @@ Mod.LoadSpriteFrame = function(identifier, buffer, inframe, frame)
 {
 	var i;
 
+	if (!frame)
+	{
+		Sys.Print('Mod.LoadSpriteFrame: invalid frame: ' + identifier);
+		return;
+	}
 	var model = new DataView(buffer);
 	frame.origin = [model.getInt32(inframe, true), -model.getInt32(inframe + 4, true)];
 	frame.width = model.getUint32(inframe + 8, true);


### PR DESCRIPTION
I was getting some errors after a fresh checkout, one seemed to be from a typo in the code (mod vs model) and the other seems to be related to some missing data in a couple sprites (maybe a version problem?).  This patch fixes the first, and works around the second.
