### PR TITLE
Fix pointer lock issue in Chrome

### DIFF
--- a/Client/WebQuake/IN.js
+++ b/Client/WebQuake/IN.js
@@ -10,7 +10,7 @@ IN.StartupMouse = function()
 	IN.m_filter = Cvar.RegisterVariable('m_filter', '1');
 	if (COM.CheckParm('-nomouse') != null)
 		return;
-	if (VID.mainwindow.pointerLockElement != null)
+	if (VID.mainwindow.requestPointerLock != null)
 	{
 		IN.movementX = 'movementX';
 		IN.movementY = 'movementY';


### PR DESCRIPTION
In newer versions of Chrome pointer lock is not working. This change makes it work again.
